### PR TITLE
refactor: bumping Gatsby version to v5

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -3,7 +3,7 @@ name: React95 Gatsby Theme - Publish workflow
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build_and_publish:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you already have a site you'd like to add the React95 theme to, you can manua
 
 1. Install the React95 theme
 
-```
+```bash
 npm install @react95/core @react95/gatsby-theme styled-components
 
 # or
@@ -123,7 +123,6 @@ modal:false
 icon:
   name: Computer
   variant: 32x32_4
-
 ---
 
 # Your website starts on this folder


### PR DESCRIPTION
BREAKING CHANGE: This is the newest version of @react95/theme, built with Gatsby v5 and node 18. Consider upgrading all your dependencies first.