### PR TITLE
refactor: bumping Gatsby version to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "react95-gatsby-theme-workspace",
-  "private": true,
   "version": "0.0.0-development",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE: This is the newest version of @react95/theme, built with Gatsby v5 and node 18. Consider upgrading all your dependencies first.